### PR TITLE
Allow ASG instances with public ip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    aws_helper (1.1.3)
+    aws_helper (1.2.0)
       aws-sdk-v1 (~> 1.66)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk-v1 (1.66.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
+      nokogiri (~> 1)
     diff-lcs (1.2.5)
-    json (1.8.3)
-    mini_portile2 (2.0.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    json (1.8.6)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     rake (11.1.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -38,5 +38,8 @@ DEPENDENCIES
   rake (~> 11.1, >= 11.1.1)
   rspec (~> 3.4)
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
-   1.11.2
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ The default RAILS_ENV is `development`.  The default LOG_LEVEL is `WARN` and it 
 
 `add_instances(n)`: adds n instances to the current autoscale group.  The current autoscale group is the first one that matches the name filter.  Autoscale groups should sort naturally (see `create_autoscale_group` below) and the first match should always be the latest one to be created.  Returns the autoscale group's new desired capacity.
 
-`create_autoscale_group(ami_id)`: creates a new auto scaling group configuration using `ami_id` to create its required launch configuration.  The following options are currently hard-coded: `key_name: 'id_lens10'`, `security_groups: ['sg-57142f2e']`, `instance_type: 't2.large'` (there are others, see `configure_autoscale_policies` in `lib/aws_helper.rb`).  It returns the name of the newly created auto scaling group in this format: `"#{CONFIG_NAME_BASE}#{Date.today.iso8601}_#{i}"`.
+`create_autoscale_group(ami_id, associate_public_ip=false)`: creates a new auto
+scaling group configuration using `ami_id` to create its required launch
+configuration.  The following options are currently hard-coded: `key_name`,
+`security_groups`, `instance_type` (see `configure_autoscale_policies` in
+`lib/aws_helper.rb` for values and other options).  It returns the name of the newly created auto
+scaling group in this format:
+`"#{CONFIG_NAME_BASE}#{Date.today.iso8601}_#{i}"`.
 
 `set_instance_userdata(id, data)`: **stops** ec2 instance with instance_id `id` and writes `data` to the [instance user-data storage](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data). The instance user data can be accessed locally, e.g.: `curl http://169.254.169.254/latest/user-data`.
 

--- a/lib/aws_helper.rb
+++ b/lib/aws_helper.rb
@@ -110,8 +110,8 @@ class AwsHelper
     return new_capacity
   end
 
-  def create_autoscale_group(ami_id)
-    launch_configuration_name = create_launch_configuration(ami_id)
+  def create_autoscale_group(ami_id, associate_public_ip=false)
+    launch_configuration_name = create_launch_configuration(ami_id, associate_public_ip)
     autoscale_group_name = get_available_scaling_group_name
 
     @client.autoscale.create_auto_scaling_group ({
@@ -422,7 +422,7 @@ class AwsHelper
     return j > timeout
   end
 
-  def create_launch_configuration(ami_id)
+  def create_launch_configuration(ami_id, associate_public_ip=false)
     launch_configuration_name = get_available_launch_configuration_name
 
     @client.autoscale.create_launch_configuration({
@@ -435,7 +435,7 @@ class AwsHelper
         enabled: false,
       },
       ebs_optimized: false,
-      associate_public_ip_address: false,
+      associate_public_ip_address: associate_public_ip,
       placement_tenancy: "default",
       user_data: Base64.encode64(RAILS_ENV)
     })

--- a/lib/aws_helper/version.rb
+++ b/lib/aws_helper/version.rb
@@ -1,3 +1,3 @@
 class AwsHelper
-  VERSION = '1.1.7'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
This will be needed to deploy worker images that create instances with public ip address.